### PR TITLE
Add support for vector commands

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject douglass/clj-psql "0.1.2-SNAPSHOT"
+(defproject douglass/clj-psql "0.1.2"
   :description "A small Clojure wrapper for interacting with Postgres via psql"
   :license "EPL 1.0"
   :url "https://github.com/DarinDouglass/clj-psql"


### PR DESCRIPTION
- These are JDBC-style vectors of the form [command &
  parameters]. These will be processed into plain string commands and
  sent off to psql.